### PR TITLE
change farms details text color

### DIFF
--- a/src/views/Bank/components/Harvest.tsx
+++ b/src/views/Bank/components/Harvest.tsx
@@ -44,8 +44,8 @@ const Harvest: React.FC<HarvestProps> = ({ bank }) => {
               <TokenSymbol symbol={bank.earnToken.symbol} />
             </CardIcon>
             <Value value={getDisplayBalance(earnings)} />
-            <Label text={`≈ $${earnedInDollars}`} />
-            <Label text={`${tokenName} Earned`} />
+            <Label text={`≈ $${earnedInDollars}`} color='#fffa'/>
+            <Label text={`${tokenName} Earned`} color='#fffa' />
           </StyledCardHeader>
           <StyledCardActions>
             <Button onClick={onReward} disabled={earnings.eq(0)} color="primary" variant="contained">

--- a/src/views/Bank/components/Stake.tsx
+++ b/src/views/Bank/components/Stake.tsx
@@ -99,8 +99,8 @@ const Stake: React.FC<StakeProps> = ({ bank }) => {
               <TokenSymbol symbol={bank.depositToken.symbol} size={54} />
             </CardIcon>
             <Value value={getDisplayBalance(stakedBalance, bank.depositToken.decimal)} />
-            <Label text={`≈ $${earnedInDollars}`} />
-            <Label text={`${bank.depositTokenName} Staked`} />
+            <Label text={`≈ $${earnedInDollars}`} color='#fffa'/>
+            <Label text={`${bank.depositTokenName} Staked`} color='#fffa' />
           </StyledCardHeader>
           <StyledCardActions>
             {approveStatus !== ApprovalState.APPROVED ? (


### PR DESCRIPTION
people on discord were complaining that the farm texts for the details of the staked/earned values are fairly unreadable. hardcoded `white` text for now

![image](https://user-images.githubusercontent.com/14729459/154059292-4df91ea6-38d1-4cdf-9f17-565bde537716.png)

to

![image](https://user-images.githubusercontent.com/14729459/154059233-d8c0c9d8-2e29-4117-b18f-33230bfe3631.png)
