### PR TITLE
fix-mobile-nav

### DIFF
--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -57,6 +57,9 @@ const useStyles = makeStyles((theme) => ({
 		fontFamily: '"Gilroy"',
 		fontSize: '30px',
 		flexGrow: 1,
+		display: 'flex',
+		justifyContent: 'center',
+		alignItems: 'center',
 	},
 	link: {
 		textTransform: 'uppercase',

--- a/src/components/Nav/Nav.tsx
+++ b/src/components/Nav/Nav.tsx
@@ -193,8 +193,20 @@ const Nav = () => {
 								{/* <ListItemLink primary="SBS" to="/sbs" />
                 <ListItemLink primary="Liquidity" to="/liquidity" />
                 <ListItemLink primary="Regulations" to="/regulations" /> */}
+								<ListItem button component="a" href="https://3omb.finance/rebates">
+									<ListItemText>3DAO</ListItemText>
+								</ListItem>
+								<ListItem button component="a" href="https://www.devilfinance.io">
+									<ListItemText>VAULTS</ListItemText>
+								</ListItem>
+								<ListItem button component="a" href="https://snapshot.org/#/forgiving.forg.eth">
+									<ListItemText>GOVERNANCE</ListItemText>
+								</ListItem>
 								<ListItem button component="a" href="https://docs.2omb.finance">
 									<ListItemText>DOCS</ListItemText>
+								</ListItem>
+								<ListItem button component="a" href="https://3omb.finance/">
+									<ListItemText>3OMB</ListItemText>
 								</ListItem>
 								<ListItem style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
 									<AccountButton text="Connect" />


### PR DESCRIPTION
Fixes:
- Mobile NavBar
- Desktop Audit

Mobile Nav is using default Tomb Fork navigation. Updating to reflect the same links as we have in the desktop app.
![Screen Shot 2022-02-15 at 1 11 25 PM](https://user-images.githubusercontent.com/5277988/154133865-74e1c68b-a361-4f38-92be-b1e5d79ab201.png)
To
![Screen Shot 2022-02-15 at 1 23 33 PM](https://user-images.githubusercontent.com/5277988/154133936-0b1be6d7-02ea-46ea-a31d-a929a10af8d9.png)

Fix audit.
![Screen Shot 2022-02-15 at 1 23 01 PM](https://user-images.githubusercontent.com/5277988/154134099-0f0faf19-b7ae-4c34-9a02-b5e15a720ea0.png)
To
![Screen Shot 2022-02-15 at 1 22 50 PM](https://user-images.githubusercontent.com/5277988/154134122-cef6e55d-b77e-42a3-a4a6-a193b0011db7.png)

